### PR TITLE
Replace mentions to brasilis

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To set up the development environment, you'll need to have Python 3.13 installed
   Clone the repository with the submodule.
 
    ```sh
-   git clone --recurse-submodules git@github.com:brasilisclub/donotcommit.git
+   git clone --recurse-submodules git@github.com:avantguarda/donotcommit.git
    cd donotcommit.com
    ```
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -4,7 +4,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="Create the perfect .gitignore file in seconds. Select your tech stack and generate a customized .gitignore for clean repositories.">
-	<meta name="author" content="Brasilis Club">
+	<meta name="author" content="Avantguarda">
 
 	<meta property="og:title" content="Git Wisely | Do Not Commit">
 	<meta property="og:description" content="Generate customized .gitignore files for your tech stack">
@@ -20,7 +20,7 @@
 	<link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png" />
 	
 	<link rel="canonical" href="https://donotcommit.com/">
-	<title>Git Wisely | Do Not Commit by Brasilis Club</title>
+	<title>Git Wisely | Do Not Commit by Avantguarda</title>
 
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -29,12 +29,12 @@
     </head>
     <body>
 	<header>
-	    <h1><a href="https://brasilis.club">brasilis</a></h1>
+	    <h1><a href="https://github.com/avantguarda">Avantguarda</a></h1>
 	    <nav>
 		<ul>
-		    <li><a href="https://github.com/brasilisclub/donotcommit">Source</a></li>
+		    <li><a href="https://github.com/avantguarda/donotcommit">Source</a></li>
 		    <li><a href="/docs">Docs</a></li>
-		    <li><a class="highlight" href="https://github.com/sponsors/brasilisclub">Support</a></li>
+		    <li><a class="highlight" href="https://github.com/sponsors/avantguarda">Support</a></li>
 		</ul>
 	    </nav>
 	</header>
@@ -55,7 +55,7 @@
 	</main>
 
 	<footer>
-	    <small>A clean repo initiative by <a href="https://brasilis.club">Brasilis Club</a> — Made in Brazil</small>
+	    <small>A clean repo initiative by <a href="https://github.com/avantguarda">Avantguarda</a> — Made in Brazil</small>
 	</footer>
 
 	<script>


### PR DESCRIPTION
### Issue
On donotcommit's homepage, there were many mentions of our former collective, Brasilis, which ended a month ago. Since this project has transitioned from Brasilis to Avantguarda, we need to replace all references to the old collective.

### Changes
Applied the necessary changes to the `index.html` and `README.md` files.
