### PR TITLE
Add client ignr.py to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For now, we are using [github/gitignore](https://github.com/github/gitignore) as
 Use one client to make your life easier when managing gitignore files:  
 - zignr: <https://github.com/ivansantiagojr/zignr>
 - ignoreme: <https://github.com/devid8642/ignoreme>
+- ignr.py: <https://github.com/Antrikshy/ignr.py>
 
 You can list your client here, just open a PR!
 


### PR DESCRIPTION
Hi. ignr.py was originally written around gitignore.io, but now points to this service!

Context: https://github.com/Antrikshy/ignr.py/pull/6

Change contributed to ignr.py by @alxwrd.