### PR TITLE
Add custom 404 page for web routes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,10 +34,11 @@ def read_root(request: Request):
 def custom_http_exception_handler(
     request: Request, exc: StarletteHTTPException
 ):
-    if exc.status_code == 404:
+    if exc.status_code == HTTPStatus.NOT_FOUND:
         if request.url.path.startswith('/api'):
             return JSONResponse(
-                status_code=404, content={'detail': 'Not Found'}
+                status_code=HTTPStatus.NOT_FOUND,
+                content={'detail': 'Not Found'},
             )
 
         return templates.TemplateResponse(

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ from typing import Final
 
 import logfire
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import HTMLResponse, PlainTextResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -31,10 +31,14 @@ def read_root(request: Request):
 
 
 @app.exception_handler(StarletteHTTPException)
-def custom_http_exception_handler(request: Request, exc: StarletteHTTPException):
+def custom_http_exception_handler(
+    request: Request, exc: StarletteHTTPException
+):
     if exc.status_code == 404:
         if request.url.path.startswith('/api'):
-            return JSONResponse(status_code=404, content={'detail': 'Not Found'})
+            return JSONResponse(
+                status_code=404, content={'detail': 'Not Found'}
+            )
 
         return templates.TemplateResponse(
             request=request,

--- a/src/main.py
+++ b/src/main.py
@@ -4,8 +4,9 @@ from typing import Final
 
 import logfire
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.responses import HTMLResponse, PlainTextResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from src.settings import settings
 from src.templates_conf import templates
@@ -27,6 +28,22 @@ TEMPLATES: Final = tuple(GITIGNORE_FOLDER.rglob('*.gitignore'))
 @app.get('/', response_class=HTMLResponse, include_in_schema=False)
 def read_root(request: Request):
     return templates.TemplateResponse(request=request, name='index.html')
+
+
+@app.exception_handler(StarletteHTTPException)
+def custom_http_exception_handler(request: Request, exc: StarletteHTTPException):
+    if exc.status_code == 404:
+        if request.url.path.startswith('/api'):
+            return JSONResponse(status_code=404, content={'detail': 'Not Found'})
+
+        return templates.TemplateResponse(
+            request=request,
+            name='404.html',
+            context={'path': request.url.path},
+            status_code=404,
+        )
+
+    raise exc
 
 
 @app.get('/api/list', response_class=PlainTextResponse)

--- a/src/templates/404.html
+++ b/src/templates/404.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="Page not found.">
+	<link rel="shortcut icon" href="/static/favicon.ico" />
+	<link rel="manifest" href="/static/site.webmanifest" />
+	<meta name="apple-mobile-web-app-title" content="DontCommit" />
+	<link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+	<link rel="icon" type="image/png" href="/static/favicon-96x96.png" sizes="96x96" />
+	<link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png" />
+
+	<title>404 | Do Not Commit by Artefatto</title>
+
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+	<link rel="stylesheet" href="/static/css/index.css">
+    </head>
+    <body>
+	<header>
+	    <h1><a href="https://github.com/artefatto">Artefatto</a></h1>
+	    <nav>
+		<ul>
+		    <li><a href="https://github.com/artefatto/donotcommit">Source</a></li>
+		    <li><a href="/docs">Docs</a></li>
+		    <li><a class="highlight" href="https://github.com/sponsors/artefatto">Support</a></li>
+		</ul>
+	    </nav>
+	</header>
+
+	<main>
+	    <section>
+		<h1>404 <br><em>Not Found</em></h1>
+		<p>The page <code>{{ path }}</code> does not exist.</p>
+		<p><a class="highlight" href="/">Go back home</a></p>
+	    </section>
+	</main>
+
+	<footer>
+	    <small>A clean repo initiative by <a href="https://ivansantiago.net">Ivan Santiago</a> and <a href="https://thigcampos.com">Thiago Campos</a>.</small>
+	</footer>
+    </body>
+</html>


### PR DESCRIPTION
Adds a custom HTML 404 page for normal web routes while preserving JSON 404 responses for missing /api routes.

Changes:
- add a global 404 handler
- return JSON for missing API routes
- render a styled 404.html template for non-API routes

Related to #30 