### PR TITLE
Setup continuos deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,14 @@
+name: Deploy to FastAPI Cloud
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+      - run: uv run fastapi deploy
+        env:
+          FASTAPI_CLOUD_TOKEN: ${{ secrets.FASTAPI_CLOUD_TOKEN }}
+          FASTAPI_CLOUD_APP_ID: ${{ secrets.FASTAPI_CLOUD_APP_ID }}


### PR DESCRIPTION
# Summary

This PR setups a CD with GitHub Actions and FastAPI cloud.

To write the file, I just ran the command `fastapi cloud setup-ci` and everything was done. I actually also needed to recreate the deploy token manually myself. The CLI created it, but I was not able to copy from anywhere.

Now, on every merge to main, we have a deploy.

# Before merge

- [x] Set the `FASTAPI_CLOUD_TOKEN` secret
- [x] Set the `FASTAPI_CLOUD_APP_ID` secret

# Issues

closes #12 