### PR TITLE
Fix logfire "Found propagated tracing"

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,7 +14,9 @@ app = FastAPI(title='donotcommit.com')
 app.mount('/static', StaticFiles(directory='src/static'), name='static')
 
 logfire.configure(
-    token=settings.LOGFIRE_TOKEN, send_to_logfire='if-token-present'
+    token=settings.LOGFIRE_TOKEN,
+    send_to_logfire='if-token-present',
+    distributed_tracing=False,
 )
 logfire.instrument_fastapi(app, capture_headers=True)
 logfire.instrument_system_metrics()


### PR DESCRIPTION
# Merge first
- #35 

# Summary

After deploy donotcommit to FastAPI cloud and setting up the logfire token, we started getting the warning "Found propagated trace context". 

# Fix

The [logfire docs](https://pydantic.dev/docs/logfire/instrument/distributed-tracing/#unintentional-distributed-tracing) suggested setting the `distributed_tracing` to False.

# Rationale

Read [this whole page](https://pydantic.dev/docs/logfire/instrument/distributed-tracing/) to understand the problem further, but I believe this has to do with both FastAPI Cloud and Logfire observing the same app.

