### PR TITLE
Use widely available sans-serif and serif css rules

### DIFF
--- a/src/static/css/index.css
+++ b/src/static/css/index.css
@@ -9,8 +9,8 @@
   --spacing-sm: 1rem;
   --spacing-md: 2rem;
   
-  --font-primary: "Helvetica Neue", ui-sans-serif;
-  --font-secondary: "Instrument Serif", ui-serif;
+  --font-primary: "Helvetica Neue", sans-serif;
+  --font-secondary: "Instrument Serif", serif;
   --font-size-base: 1rem;
   --font-size-large: 2rem;
   --font-size-xlarge: clamp(5rem, 10vw, 8rem);


### PR DESCRIPTION
### Summary
I missed that ui-sans-serif and ui-serif have a limited availability, basically they are only supported by Safari.

**References**
- https://caniuse.com/?search=ui-serif
- https://caniuse.com/?search=ui-sans-serif

### Screenshots

Before:
<img width="1271" height="1017" alt="image" src="https://github.com/user-attachments/assets/cf6db686-f735-42b1-8db0-06c1f4d07209" />

After:
<img width="1271" height="1017" alt="image" src="https://github.com/user-attachments/assets/053ccca8-307b-4e31-8370-e108e2948e32" />


